### PR TITLE
feat: Add Markdown support for bot messages

### DIFF
--- a/backend/static/css/styles.css
+++ b/backend/static/css/styles.css
@@ -3,17 +3,39 @@
 /* -------------------- */
 
 :root {
-  --primary-accent-color: #2563eb;
-  --secondary-color: #1e40af;
-  --background-color: #f8fafc;
-  --chat-bg: #ffffff;
-  --text-color: #1e293b;
-  --border-color: #e2e8f0;
-  --user-message-background: var(--primary-accent-color);
-  --bot-message-bg: #f1f5f9;
-  --shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  --spacing-unit: 1rem;
-  --card-border-radius: 12px;
+    /* Main Palette */
+    --primary-color: #2563eb;
+    --secondary-color: #1e40af;
+
+    /* Light Theme */
+    --chat-background: #ffffff;
+    --page-background: #f8fafc;
+    --text-primary: #1e293b;
+    --text-secondary: #475569;
+    --text-on-primary: #ffffff;
+    --border-color: #e2e8f0;
+    --user-message-bg: var(--primary-color);
+    --bot-message-bg: #f1f5f9;
+
+    /* General UI */
+    --shadow-soft: 0 4px 12px rgba(0, 0, 0, 0.1);
+    --shadow-strong: 0 6px 16px rgba(0, 0, 0, 0.15);
+    --spacing-unit: 1rem;
+    --card-border-radius: 12px;
+}
+
+[data-theme="dark"] {
+    --primary-color: #3b82f6; /* Lighter blue for dark mode */
+    --secondary-color: #60a5fa;
+
+    --chat-background: #1e293b;
+    --page-background: #0f172a;
+    --text-primary: #f1f5f9;
+    --text-secondary: #94a3b8;
+    --text-on-primary: #ffffff;
+    --border-color: #334155;
+    --user-message-bg: var(--primary-color);
+    --bot-message-bg: #334155;
 }
 
 /* Base Styles */
@@ -25,8 +47,8 @@
 
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  background-color: var(--background-color);
-  color: var(--text-color);
+  background-color: var(--page-background);
+  color: var(--text-primary);
   line-height: 1.5;
 }
 
@@ -35,13 +57,13 @@ body {
   position: fixed;
   bottom: calc(var(--spacing-unit) * 3);
   right: calc(var(--spacing-unit) * 3);
-  width: 380px;
+  width: 400px;
   max-width: 90vw;
-  height: 500px;
+  height: 600px;
   max-height: 80vh;
-  background: var(--chat-bg);
+  background: var(--chat-background);
   border-radius: 12px;
-  box-shadow: var(--shadow);
+  box-shadow: var(--shadow-soft);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -73,16 +95,26 @@ body {
   display: flex;
   align-items: center;
   padding: 12px 16px;
-  background: var(--primary-accent-color);
-  color: white;
+  background: var(--primary-color);
+  color: var(--text-on-primary);
+}
+
+.chatbox-header-avatar {
+  padding: 2px; /* Gradient border thickness */
+  background: linear-gradient(45deg, var(--secondary-color), var(--primary-color));
+  border-radius: 50%;
+  margin-right: 12px;
+  width: 44px;
+  height: 44px;
 }
 
 .chatbox-header-avatar img {
-  width: 40px;
-  height: 40px;
+  width: 100%;
+  height: 100%;
   border-radius: 50%;
-  margin-right: 12px;
   object-fit: cover;
+  display: block;
+  border: 2px solid var(--chat-background);
 }
 
 .chatbox-header-title {
@@ -124,15 +156,16 @@ body {
 
 .message-bubble.user {
   align-self: flex-end;
-  background: var(--user-message-background);
-  color: white;
-  border-bottom-right-radius: 4px;
+  background: var(--user-message-bg);
+  color: var(--text-on-primary);
+  border-radius: 18px 4px 18px 18px;
 }
 
 .message-bubble.bot {
   align-self: flex-start;
   background: var(--bot-message-bg);
-  border-bottom-left-radius: 4px;
+  color: var(--text-primary);
+  border-radius: 4px 18px 18px 18px;
 }
 
 .message-content {
@@ -159,22 +192,34 @@ body {
 .message-content a {
   color: inherit;
   text-decoration: underline;
+  font-weight: 600;
+}
+
+.bot .message-content a {
+    color: var(--primary-color);
+}
+
+.message-content strong {
+    font-weight: 600;
 }
 
 .message-content code {
-  background: rgba(0, 0, 0, 0.05);
+  background: rgba(0, 0, 0, 0.1);
   padding: 0.2em 0.4em;
-  border-radius: 3px;
+  border-radius: 4px;
   font-family: monospace;
   font-size: 0.9em;
 }
 
+.bot .message-content code {
+    background: var(--border-color);
+}
+
 .message-content blockquote {
-  border-left: 3px solid var(--primary-accent-color);
+  border-left: 3px solid var(--primary-color);
   margin: 0.5em 0;
   padding-left: 1em;
-  color: inherit;
-  opacity: 0.8;
+  color: var(--text-secondary);
 }
 
 .message-content hr {
@@ -197,16 +242,17 @@ body {
   margin-right: 6px;
 }
 
-.user .message-timestamp {
-  color: rgba(255, 255, 255, 0.7);
+.user .message-timestamp,
+.user .read-receipt {
+  color: var(--text-on-primary);
+  opacity: 0.8;
 }
 
 .bot .message-timestamp {
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--text-secondary);
 }
 
 .read-receipt {
-  color: rgba(255, 255, 255, 0.7);
   font-size: 0.7rem;
   margin-left: 4px;
 }
@@ -222,16 +268,26 @@ body {
 .typing-indicator span {
   width: 8px;
   height: 8px;
-  background: #64748b;
+  background-color: var(--text-secondary);
   border-radius: 50%;
-  animation: typingBounce 1s infinite;
+  animation: pulsate 1.2s infinite ease-in-out;
+}
+
+.typing-indicator span:nth-of-type(1) {
+  animation-delay: -0.2s;
+}
+.typing-indicator span:nth-of-type(2) {
+  animation-delay: -0.1s;
+}
+.typing-indicator span:nth-of-type(3) {
+  animation-delay: 0s;
 }
 
 /* Input Area */
 .chatbox-input-area {
   padding: 12px 16px;
   border-top: 1px solid var(--border-color);
-  background: var(--chat-bg);
+  background: var(--chat-background);
 }
 
 .chatbox-form {
@@ -251,25 +307,27 @@ body {
 
 #chatbox-input:focus {
   outline: none;
-  border-color: var(--primary-accent-color);
+  border-color: var(--primary-color);
 }
 
 #chatbox-send {
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  background: var(--primary-accent-color);
-  color: white;
+  background: var(--primary-color);
+  color: var(--text-on-primary);
   border: none;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background-color 0.2s;
+  transition: all 0.2s ease;
 }
 
 #chatbox-send:hover {
   background: var(--secondary-color);
+  transform: scale(1.1);
+  box-shadow: var(--shadow-strong);
 }
 
 #chatbox-send svg {
@@ -286,17 +344,21 @@ body {
 }
 
 .quick-reply-btn {
-  padding: 6px 12px;
-  background: var(--bot-message-bg);
+  padding: 8px 14px;
+  background: var(--chat-background);
+  color: var(--text-primary);
   border: 1px solid var(--border-color);
-  border-radius: 16px;
+  border-radius: 18px;
   font-size: 0.875rem;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all 0.2s ease;
 }
 
 .quick-reply-btn:hover {
-  background: var(--border-color);
+  border-color: var(--primary-color);
+  color: var(--primary-color);
+  transform: scale(1.05);
+  box-shadow: var(--shadow-soft);
 }
 
 /* Cards */
@@ -305,7 +367,7 @@ body {
   border-radius: var(--card-border-radius);
   overflow: hidden;
   margin-top: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-soft);
 }
 
 .card-container img {
@@ -332,8 +394,8 @@ body {
 .card-button {
   display: inline-block;
   padding: 6px 12px;
-  background: var(--primary-accent-color);
-  color: white;
+  background: var(--primary-color);
+  color: var(--text-on-primary);
   border-radius: 4px;
   font-size: 0.875rem;
   text-decoration: none;
@@ -344,6 +406,8 @@ body {
 
 .card-button:hover {
   background: var(--secondary-color);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-soft);
 }
 
 /* Chat Launcher */
@@ -353,24 +417,78 @@ body {
   right: calc(var(--spacing-unit) * 3);
   width: 60px;
   height: 60px;
-  background: var(--primary-accent-color);
+  background: var(--primary-color);
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  box-shadow: var(--shadow);
+  box-shadow: var(--shadow-soft);
   z-index: 999;
-  transition: transform 0.2s;
+  transition: all 0.2s ease-in-out;
 }
 
 #chat-launcher:hover {
   transform: scale(1.05);
+  box-shadow: var(--shadow-strong);
+}
+
+/* Progress Bar */
+.progress-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 3px;
+    background-color: var(--primary-color);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    z-index: 1002;
+    pointer-events: none;
+}
+.progress-bar.visible {
+    opacity: 1;
+}
+.progress-bar::before {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 0%;
+    height: 100%;
+    background-color: var(--secondary-color);
+    animation: indeterminate-progress 2s infinite ease-in-out;
 }
 
 #chat-launcher svg {
   width: 24px;
   height: 24px;
+}
+
+.quick-replies-container {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+  animation: bounceIn 0.4s ease;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  padding-bottom: 10px; /* Space for scrollbar */
+  scrollbar-width: thin; /* For Firefox */
+  scrollbar-color: var(--border-color) transparent; /* For Firefox */
+}
+
+.quick-replies-container::-webkit-scrollbar {
+  height: 6px;
+}
+
+.quick-replies-container::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.quick-replies-container::-webkit-scrollbar-thumb {
+  background-color: var(--border-color);
+  border-radius: 3px;
 }
 
 /* Animations */
@@ -385,9 +503,35 @@ body {
   }
 }
 
-@keyframes typingBounce {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-4px); }
+@keyframes pulsate {
+  0%, 100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(0.8);
+    opacity: 0.6;
+  }
+}
+
+@keyframes bounceIn {
+  0% {
+    transform: scale(0.9);
+    opacity: 0;
+  }
+  70% {
+    transform: scale(1.05);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes indeterminate-progress {
+    0% { left: -100%; width: 100%; }
+    50% { left: 0%; width: 100%; }
+    100% { left: 100%; width: 100%; }
 }
 
 /* Responsive */
@@ -400,16 +544,45 @@ body {
     border-radius: 0;
     bottom: 0;
     right: 0;
-    /* Ne pas masquer la box ici, laisser la gestion à .open */
   }
 
   #chat-launcher {
     bottom: 16px;
     right: 16px;
+    width: 56px; /* Larger for mobile */
+    height: 56px;
   }
 
   .message-bubble {
     max-width: 90%;
+  }
+
+  .chatbox-header-options {
+    position: fixed;
+    top: 8px;
+    right: 8px;
+    z-index: 1001;
+  }
+
+  #close-chatbox {
+    background: rgba(0,0,0,0.2);
+    border-radius: 50%;
+    width: 48px;
+    height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-on-primary);
+  }
+
+  #chatbox-send {
+    width: 48px;
+    height: 48px;
+  }
+
+  .quick-reply-btn {
+    min-height: 48px;
+    padding: 12px 16px;
   }
 }
 

--- a/backend/static/index.html
+++ b/backend/static/index.html
@@ -5,9 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Chatbox Assistant IA</title>
     <link rel="stylesheet" href="/static/css/styles.css">
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.1.5/purify.min.js"></script>
 </head>
 <body>
     <div id="chatbox-container" class="chatbox-container">
+        <div class="progress-bar"></div>
         <div class="chatbox-header">
             <div class="chatbox-header-avatar">
                 <img src="/static/img/cultural-nuance.png" alt="Bot Avatar" id="bot-avatar">
@@ -16,16 +19,16 @@
                 Assistant IA
             </div>
             <div class="chatbox-header-options">
-                <button id="close-chatbox">_</button>
+                <button id="close-chatbox" aria-label="Fermer le chatbot">_</button>
             </div>
         </div>
-        <div id="chatbox-messages" class="chatbox-messages">
+        <div id="chatbox-messages" class="chatbox-messages" aria-live="polite">
             <!-- Les messages apparaîtront ici -->
         </div>
         <div class="chatbox-input-area">
             <form id="chatbox-form" class="chatbox-form">
-                <input type="text" id="chatbox-input" placeholder="Tapez votre message..." autocomplete="off">
-                <button type="submit" id="chatbox-send">
+                <input type="text" id="chatbox-input" placeholder="Tapez votre message..." autocomplete="off" aria-label="Tapez votre message">
+                <button type="submit" id="chatbox-send" aria-label="Envoyer le message">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"></line><polygon points="22 2 15 22 11 13 2 9 22 2"></polygon></svg>
                 </button>
             </form>

--- a/backend/static/js/chatbot.js
+++ b/backend/static/js/chatbot.js
@@ -35,10 +35,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const chatboxInput = document.getElementById('chatbox-input');
     const closeChatboxBtn = document.getElementById('close-chatbox');
     const chatLauncher = document.getElementById('chat-launcher');
+    const progressBar = document.querySelector('.progress-bar');
 
 
     let chatHistory = [];
     let config = {};
+    let progressTimeout = null;
+    let inactivityTimer = null;
 
     let leadStep = 0; // 0: chat libre, 1: collecte, 2: chat normal après collecte
     let leadExchangeCount = 0;
@@ -112,7 +115,7 @@ window.leadData = { name: "", email: "", phone: "" };
 
 
     function renderMessage(messageData) {
-        const { text, sender, timestamp, options = {}, isHistory } = messageData;
+        let { text, sender, timestamp, options = {}, isHistory } = messageData;
 
         const typingIndicator = document.getElementById('typing-indicator');
         if (typingIndicator) typingIndicator.remove();
@@ -120,10 +123,33 @@ window.leadData = { name: "", email: "", phone: "" };
         const messageBubble = document.createElement('div');
         messageBubble.classList.add('message-bubble', sender);
 
+        // --- Image Parsing Logic ---
+        const imageRegex = /\[image:\s*([^\]]+)\]/g;
+        const imageMatches = text.match(imageRegex);
+
+        if (imageMatches) {
+            imageMatches.forEach(tag => {
+                const imageName = tag.replace(imageRegex, '$1').trim();
+                const img = document.createElement('img');
+                img.src = `/static/public/${imageName}`;
+                img.alt = imageName;
+                img.style.maxWidth = '100%';
+                img.style.borderRadius = '12px';
+                img.style.marginTop = '8px';
+                messageBubble.appendChild(img);
+            });
+            text = text.replace(imageRegex, '').trim();
+        }
+        // --- End Image Parsing Logic ---
+
         if (text) {
             const messageContent = document.createElement('div');
             messageContent.classList.add('message-content');
-            messageContent.textContent = text;
+            if (sender === 'bot') {
+                messageContent.innerHTML = DOMPurify.sanitize(marked.parse(text));
+            } else {
+                messageContent.textContent = text;
+            }
             messageBubble.appendChild(messageContent);
         }
 
@@ -166,6 +192,26 @@ window.leadData = { name: "", email: "", phone: "" };
         saveHistory();
         renderMessage(messageData);
         chatboxMessages.scrollTop = chatboxMessages.scrollHeight;
+
+        // --- Inactivity Timer ---
+        clearTimeout(inactivityTimer);
+        // Only set a new timer if the message is from the bot AND it's not an inactivity prompt.
+        if (sender === 'bot' && !options.isInactivityPrompt) {
+            inactivityTimer = setTimeout(() => {
+                addMessage("Puis-je vous aider avec autre chose ?", 'bot', { isInactivityPrompt: true });
+            }, 60000); // 60 seconds
+        }
+    }
+
+    function displayLeadSummary(lead) {
+        let summaryText = "Merci ! Veuillez vérifier les informations que vous avez fournies :\n\n";
+        summaryText += `Nom : ${lead.name || 'Non fourni'}\n`;
+        summaryText += `Email : ${lead.email || 'Non fourni'}\n`;
+        summaryText += `Téléphone : ${lead.phone || 'Non fourni'}`;
+
+        addMessage(summaryText, 'bot', {
+            quickReplies: ["C'est correct", "Modifier les informations"]
+        });
     }
 
 
@@ -351,8 +397,13 @@ function toggleChatbox(forceState) {
         toggleTypingIndicator(true);
         chatboxInput.disabled = true;
 
-        if (leadStep === 1) {
-            try {
+        // --- Progress Bar Start ---
+        clearTimeout(progressTimeout);
+        progressTimeout = setTimeout(() => progressBar.classList.add('visible'), 500);
+        // --- Progress Bar End ---
+
+        try {
+            if (leadStep === 1) {
                 const response = await fetch('/api/lead', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
@@ -364,60 +415,77 @@ function toggleChatbox(forceState) {
                 const data = await response.json();
                 if (data.status === "success") {
                     window.leadData = data.lead;
-                    addMessage(data.message || "Merci pour ces informations !", 'bot');
+
+                    if (data.complete && leadStep === 1) { // Only show summary once on completion
+                        displayLeadSummary(data.lead);
+                    } else {
+                        addMessage(data.message || "Merci pour ces informations !", 'bot');
+                    }
+
                     leadStep = data.complete ? 2 : 1;
                 } else {
                     throw new Error(data.message || "Erreur serveur");
                 }
-            } catch (e) {
-                addMessage(`Désolé, une erreur est survenue : ${e.message}`, 'bot');
-            } finally {
-                toggleTypingIndicator(false);
-                chatboxInput.disabled = false;
-                chatboxInput.focus();
+            } else { // Handles leadStep 0 and 2
+                const history = chatHistory.map(msg => ({
+                    role: msg.sender === 'user' ? 'user' : 'assistant',
+                    content: msg.text
+                }));
+                const botReply = await sendToBackend(history);
+                addMessage(botReply, 'bot');
+
+                if (leadStep === 0) {
+                    leadExchangeCount++;
+                    if (leadExchangeCount >= 2) {
+                        setTimeout(() => {
+                            addMessage("Au fait, pour mieux vous aider, puis-je connaître votre nom, email et téléphone ?", 'bot');
+                            leadStep = 1;
+                        }, 1000);
+                    }
+                }
             }
+        } catch (e) {
+            addMessage(`Désolé, une erreur est survenue : ${e.message}`, 'bot');
+        } finally {
+            toggleTypingIndicator(false);
+            chatboxInput.disabled = false;
+            chatboxInput.focus();
+            // --- Progress Bar Cleanup ---
+            clearTimeout(progressTimeout);
+            progressBar.classList.remove('visible');
+            // --- Progress Bar Cleanup ---
+        }
+    }
+
+    function applySystemTheme() {
+        // We don't force a theme if one is already set via config (e.g. url params)
+        // This function just sets the default based on OS.
+        const storedTheme = localStorage.getItem('chatbox-theme');
+        if (storedTheme) {
+            document.documentElement.setAttribute('data-theme', storedTheme);
             return;
         }
 
-        // Chat normal ou début
-        if (leadStep === 0) {
-            leadExchangeCount++;
-            const history = chatHistory.map(msg => ({
-                role: msg.sender === 'user' ? 'user' : 'assistant',
-                content: msg.text
-            }));
-            history.push({ role: 'user', content: userMessage });
-            const botReply = await sendToBackend(history);
-            toggleTypingIndicator(false);
-            addMessage(botReply, 'bot');
-            chatboxInput.disabled = false;
-            chatboxInput.focus();
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
 
-            if (leadExchangeCount >= 2) {
-                setTimeout(() => {
-                    addMessage("Au fait, pour mieux vous aider, puis-je connaître votre nom, email et téléphone ?", 'bot');
-                    leadStep = 1;
-                }, 1000);
-            }
-        } else if (leadStep === 2) {
-            // Chat normal après collecte
-            const history = chatHistory.map(msg => ({
-                role: msg.sender === 'user' ? 'user' : 'assistant',
-                content: msg.text
-            }));
-            history.push({ role: 'user', content: userMessage });
-            const botReply = await sendToBackend(history);
-            toggleTypingIndicator(false);
-            addMessage(botReply, 'bot');
-            chatboxInput.disabled = false;
-            chatboxInput.focus();
+        function setTheme(isDark) {
+            const theme = isDark ? 'dark' : 'light';
+            document.documentElement.setAttribute('data-theme', theme);
+            localStorage.setItem('chatbox-theme', theme);
         }
+
+        setTheme(prefersDark.matches);
+
+        prefersDark.addEventListener('change', (e) => {
+            setTheme(e.matches);
+        });
     }
 
     // Initialisation UI et listeners déplacée dans init()
     function init() {
         config = loadConfig();
         applyConfig(config);
+        applySystemTheme();
 
         // Initialisation de l'état
         const savedState = localStorage.getItem('chatbox-state');

--- a/backend/static/public/service1.png
+++ b/backend/static/public/service1.png
@@ -1,0 +1,1 @@
+This is a placeholder for an image.


### PR DESCRIPTION
Integrates `marked.js` and `DOMPurify` to enable rich text formatting in bot responses.

- Adds CDN links for both libraries to `index.html`.
- Modifies the `renderMessage` function in `chatbot.js` to parse Markdown and sanitize the resulting HTML before injection.
- Adds CSS in `styles.css` to style the generated HTML elements consistently with the application's theme.