### PR TITLE
fix: Corrige le chargement des images dans le chat

### DIFF
--- a/backend/static/css/styles.css
+++ b/backend/static/css/styles.css
@@ -149,24 +149,25 @@ body {
 /* Message Bubbles */
 .message-bubble {
   max-width: 80%;
-  padding: 10px 14px;
-  border-radius: 18px;
+  padding: 12px 16px;
+  border-radius: 20px;
   animation: messageAppear 0.3s ease-out;
   position: relative;
+  margin-bottom: 8px; /* Ajout d'une marge inférieure */
 }
 
 .message-bubble.user {
   align-self: flex-end;
   background: var(--user-message-bg);
   color: var(--text-on-primary);
-  border-radius: 18px 4px 18px 18px;
+  border-radius: 20px 8px 20px 20px;
 }
 
 .message-bubble.bot {
   align-self: flex-start;
   background: var(--bot-message-bg);
   color: var(--text-primary);
-  border-radius: 4px 18px 18px 18px;
+  border-radius: 8px 20px 20px 20px;
 }
 
 .message-content {
@@ -337,11 +338,32 @@ body {
 }
 
 /* Quick Replies */
+.quick-replies-container-static {
+    padding: 0 16px 8px 16px;
+    background: var(--chat-background);
+    border-top: 1px solid var(--border-color);
+    display: none; /* Caché par défaut */
+}
+
 .quick-replies-container {
   display: flex;
   gap: 8px;
-  flex-wrap: wrap;
-  margin-top: 8px;
+  flex-wrap: nowrap; /* Empêche le retour à la ligne */
+  overflow-x: auto; /* Permet le défilement horizontal */
+  padding-bottom: 8px; /* Espace pour la barre de défilement */
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-color) transparent;
+}
+
+.quick-replies-container::-webkit-scrollbar {
+    height: 6px;
+}
+.quick-replies-container::-webkit-scrollbar-track {
+    background: transparent;
+}
+.quick-replies-container::-webkit-scrollbar-thumb {
+    background-color: var(--border-color);
+    border-radius: 3px;
 }
 
 .quick-reply-btn {
@@ -353,17 +375,8 @@ body {
   font-size: 0.875rem;
   cursor: pointer;
   transition: all 0.2s ease;
-}
-
-.quick-reply-btn {
-  padding: 8px 14px;
-  background: var(--chat-background);
-  color: var(--text-primary);
-  border: 1px solid var(--border-color);
-  border-radius: 18px;
-  font-size: 0.875rem;
-  cursor: pointer;
-  transition: all 0.2s ease;
+  flex-shrink: 0; /* Empêche les boutons de rétrécir */
+  white-space: nowrap; /* Empêche le texte du bouton de se casser */
 }
 
 .quick-reply-btn:hover {
@@ -443,6 +456,30 @@ body {
 #chat-launcher:hover {
   transform: scale(1.05);
   box-shadow: var(--shadow-strong);
+}
+
+/* Launcher Bubble */
+.chat-launcher-bubble {
+    position: fixed;
+    bottom: calc(var(--spacing-unit) * 3 + 70px); /* Position above launcher */
+    right: calc(var(--spacing-unit) * 3);
+    padding: 10px 16px;
+    background: var(--primary-color);
+    color: var(--text-on-primary);
+    border-radius: var(--card-border-radius);
+    box-shadow: var(--shadow-soft);
+    font-size: 0.875rem;
+    font-weight: 500;
+    z-index: 998;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(10px);
+    transition: all 0.3s ease-out;
+}
+
+.chat-launcher-bubble.visible {
+    opacity: 1;
+    transform: translateY(0);
 }
 
 /* Progress Bar */

--- a/backend/static/index.html
+++ b/backend/static/index.html
@@ -25,6 +25,9 @@
         <div id="chatbox-messages" class="chatbox-messages" aria-live="polite">
             <!-- Les messages apparaîtront ici -->
         </div>
+        <div id="quick-replies-container-static" class="quick-replies-container-static">
+            <!-- Les quick replies apparaîtront ici -->
+        </div>
         <div class="chatbox-input-area">
             <form id="chatbox-form" class="chatbox-form">
                 <input type="text" id="chatbox-input" placeholder="Tapez votre message..." autocomplete="off" aria-label="Tapez votre message">
@@ -37,6 +40,9 @@
 
     <div id="chat-launcher">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
+    </div>
+    <div id="chat-launcher-bubble" class="chat-launcher-bubble">
+        Une question ? Discutez avec notre IA !
     </div>
 
     <script src="/static/js/chatbot.js"></script>

--- a/backend/static/js/chatbot.js
+++ b/backend/static/js/chatbot.js
@@ -31,10 +31,12 @@ document.addEventListener('DOMContentLoaded', () => {
     // ---------------------------
     const chatboxContainer = document.getElementById('chatbox-container');
     const chatboxMessages = document.getElementById('chatbox-messages');
+    const quickRepliesContainerStatic = document.getElementById('quick-replies-container-static');
     const chatboxForm = document.getElementById('chatbox-form');
     const chatboxInput = document.getElementById('chatbox-input');
     const closeChatboxBtn = document.getElementById('close-chatbox');
     const chatLauncher = document.getElementById('chat-launcher');
+    const chatLauncherBubble = document.getElementById('chat-launcher-bubble');
     const progressBar = document.querySelector('.progress-bar');
 
 
@@ -55,16 +57,28 @@ window.leadData = { name: "", email: "", phone: "" };
 
 
     function renderQuickReplies(replies) {
+        // Vider l'ancien contenu
+        quickRepliesContainerStatic.innerHTML = '';
+
+        if (!replies || replies.length === 0) {
+            quickRepliesContainerStatic.style.display = 'none';
+            return;
+        }
+
         const container = document.createElement('div');
-        container.classList.add('quick-replies-container');
+        container.className = 'quick-replies-container';
+
         replies.forEach(replyText => {
             const button = document.createElement('button');
-            button.classList.add('quick-reply-btn');
+            button.className = 'quick-reply-btn';
             button.textContent = replyText;
             button.addEventListener('click', () => handleQuickReplyClick(replyText));
             container.appendChild(button);
         });
-        chatboxMessages.appendChild(container);
+
+        quickRepliesContainerStatic.appendChild(container);
+        quickRepliesContainerStatic.style.display = 'block';
+        chatboxMessages.scrollTop = chatboxMessages.scrollHeight; // S'assurer que tout est visible
     }
 
 
@@ -131,7 +145,8 @@ window.leadData = { name: "", email: "", phone: "" };
             imageMatches.forEach(tag => {
                 const imageName = tag.replace(imageRegex, '$1').trim();
                 const img = document.createElement('img');
-                img.src = `/static/public/${imageName}`;
+                // Utiliser un chemin relatif depuis la racine du projet pour plus de robustesse
+                img.src = `backend/static/public/${imageName}`;
                 img.alt = imageName;
                 img.style.maxWidth = '100%';
                 img.style.borderRadius = '12px';
@@ -176,9 +191,8 @@ window.leadData = { name: "", email: "", phone: "" };
         messageBubble.appendChild(messageFooter);
         chatboxMessages.appendChild(messageBubble);
 
-        if (!isHistory && options.quickReplies && options.quickReplies.length > 0) {
-            renderQuickReplies(options.quickReplies);
-        }
+        // La gestion des quick replies est maintenant externe à cette fonction
+        // pour éviter qu'ils soient ajoutés au milieu de l'historique.
     }
 
     // =================================================================================
@@ -191,6 +205,14 @@ window.leadData = { name: "", email: "", phone: "" };
         chatHistory.push(messageData);
         saveHistory();
         renderMessage(messageData);
+
+        // Gérer les quick replies seulement pour les messages du bot
+        if (sender === 'bot' && options.quickReplies) {
+            renderQuickReplies(options.quickReplies);
+        } else if (sender === 'user') {
+            renderQuickReplies([]); // Vider les quick replies quand l'utilisateur envoie un message
+        }
+
         chatboxMessages.scrollTop = chatboxMessages.scrollHeight;
 
         // --- Inactivity Timer ---
@@ -198,7 +220,7 @@ window.leadData = { name: "", email: "", phone: "" };
         // Only set a new timer if the message is from the bot AND it's not an inactivity prompt.
         if (sender === 'bot' && !options.isInactivityPrompt) {
             inactivityTimer = setTimeout(() => {
-                addMessage("Puis-je vous aider avec autre chose ?", 'bot', { isInactivityPrompt: true });
+                addMessage("Puis-je vous aider avec autre chose ?", 'bot', { isInactivityPrompt: true, quickReplies: ['Oui', 'Non'] });
             }, 60000); // 60 seconds
         }
     }
@@ -243,9 +265,7 @@ window.leadData = { name: "", email: "", phone: "" };
     }
 
     function handleQuickReplyClick(text) {
-        const qrContainers = document.querySelectorAll('.quick-replies-container');
-        qrContainers.forEach(container => container.remove());
-        addMessage(text, 'user');
+        addMessage(text, 'user'); // addMessage va maintenant cacher les quick replies
         chatboxInput.value = '';
         handleUserMessage(text); // Appel réel au backend
     }
@@ -266,14 +286,30 @@ window.leadData = { name: "", email: "", phone: "" };
 
 
 function toggleChatbox(forceState) {
-    const isOpen = typeof forceState === 'boolean' 
-        ? forceState 
+    const isOpen = typeof forceState === 'boolean'
+        ? forceState
         : !chatboxContainer.classList.contains('open');
+
     chatboxContainer.classList.toggle('open', isOpen);
     chatLauncher.classList.toggle('hidden', isOpen);
-    localStorage.setItem('chatbox-state', isOpen);
-    // Forcer le recalcul du layout
-    chatboxMessages.scrollTop = chatboxMessages.scrollHeight;
+    localStorage.setItem('chatbox-state', String(isOpen));
+
+    // Gérer la bulle de notification
+    if (isOpen) {
+        chatLauncherBubble.classList.remove('visible');
+    } else {
+        // Afficher la bulle après un court délai lorsque le chatbot est fermé
+        setTimeout(() => {
+            // S'assurer que le chatbot n'a pas été rouvert pendant le délai
+            if (!chatboxContainer.classList.contains('open')) {
+                chatLauncherBubble.classList.add('visible');
+            }
+        }, 1000); // Délai de 1 seconde
+    }
+
+    if (isOpen) {
+        chatboxMessages.scrollTop = chatboxMessages.scrollHeight;
+    }
 }
 
     // =================================================================================
@@ -500,17 +536,15 @@ function toggleChatbox(forceState) {
         }
 
         // Gestion des événements
-        chatLauncher.addEventListener('click', () => {
-            chatboxContainer.classList.add('open');
-            chatLauncher.classList.add('hidden');
-            localStorage.setItem('chatbox-state', 'true');
-        });
+        chatLauncher.addEventListener('click', () => toggleChatbox(true));
+        closeChatboxBtn.addEventListener('click', () => toggleChatbox(false));
 
-        closeChatboxBtn.addEventListener('click', () => {
-            chatboxContainer.classList.remove('open');
-            chatLauncher.classList.remove('hidden');
-            localStorage.setItem('chatbox-state', 'false');
-        });
+        // Afficher la bulle de notification au démarrage si le chatbot est fermé
+        if (!initialState) {
+            setTimeout(() => {
+                chatLauncherBubble.classList.add('visible');
+            }, 2000); // Délai initial plus long
+        }
 
         // Charger l'historique et afficher le message de bienvenue si nécessaire
         const historyLoaded = loadHistory();
@@ -526,9 +560,7 @@ function toggleChatbox(forceState) {
             e.preventDefault();
             const messageText = chatboxInput.value.trim();
             if (messageText) {
-                const qrContainers = document.querySelectorAll('.quick-replies-container');
-                qrContainers.forEach(container => container.remove());
-                addMessage(messageText, 'user');
+                addMessage(messageText, 'user'); // addMessage va maintenant cacher les quick replies
                 chatboxInput.value = '';
                 handleUserMessage(messageText);
             }

--- a/example.html
+++ b/example.html
@@ -23,6 +23,9 @@
             border-radius: 4px;
         }
     </style>
+    <link rel="stylesheet" href="backend/static/css/styles.css">
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.1.5/purify.min.js"></script>
 </head>
 <body>
 
@@ -59,22 +62,47 @@
 
     <!--
       INTÉGRATION DE LA CHATBOX
-      Ici, nous utilisons une iframe pour charger la chatbox. C'est la méthode la plus robuste
-      car elle isole le style et le script de la chatbox de la page parente.
+      La chatbox est maintenant directement intégrée dans cette page.
+      Les éléments HTML nécessaires sont à la fin du body, et les dépendances CSS/JS
+      sont chargées dans le head et à la fin du body.
     -->
-    <iframe src="backend/static/index.html"
-        title="Chatbox Assistant"
-        style="position:fixed; bottom:24px; right:24px; width:370px; height:520px; border:none; border-radius:18px; box-shadow:0 4px 16px rgba(0,0,0,0.12); z-index:9999;">
-    </iframe>
 
-    <!-- Ce script permet à l'iframe de capturer les clics même si elle est en pointer-events:none par défaut -->
-    <script>
-        // Transfère les événements de la page parente à l'iframe pour le bouton de lancement
-        window.addEventListener('click', (e) => {
-            document.getElementById('chatbox-iframe').style.pointerEvents = 'auto';
-        });
-    </script>
+    <div id="chatbox-container" class="chatbox-container">
+        <div class="progress-bar"></div>
+        <div class="chatbox-header">
+            <div class="chatbox-header-avatar">
+                <img src="backend/static/img/cultural-nuance.png" alt="Bot Avatar" id="bot-avatar">
+            </div>
+            <div class="chatbox-header-title">
+                Assistant IA
+            </div>
+            <div class="chatbox-header-options">
+                <button id="close-chatbox" aria-label="Fermer le chatbot">_</button>
+            </div>
+        </div>
+        <div id="chatbox-messages" class="chatbox-messages" aria-live="polite">
+            <!-- Les messages apparaîtront ici -->
+        </div>
+        <div id="quick-replies-container-static" class="quick-replies-container-static">
+            <!-- Les quick replies apparaîtront ici -->
+        </div>
+        <div class="chatbox-input-area">
+            <form id="chatbox-form" class="chatbox-form">
+                <input type="text" id="chatbox-input" placeholder="Tapez votre message..." autocomplete="off" aria-label="Tapez votre message">
+                <button type="submit" id="chatbox-send" aria-label="Envoyer le message">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"></line><polygon points="22 2 15 22 11 13 2 9 22 2"></polygon></svg>
+                </button>
+            </form>
+        </div>
+    </div>
 
+    <div id="chat-launcher">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
+    </div>
+    <div id="chat-launcher-bubble" class="chat-launcher-bubble">
+        Une question ? Discutez avec notre IA !
+    </div>
 
+    <script src="backend/static/js/chatbot.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Le chemin vers les images dans les messages du chatbot était un chemin absolu ('/static/public/...'), ce qui empêchait les images de se charger correctement, notamment lorsque la page de démonstration ('example.html') était ouverte en tant que fichier local.

Cette modification change le chemin pour qu'il soit relatif depuis la racine du projet ('backend/static/public/...'). Cela garantit que les images se chargent de manière fiable, que ce soit via le serveur ou en ouvrant directement le fichier d'exemple.