### PR TITLE
I've improved the lead history and editing features by adding checks …

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -333,6 +333,8 @@ def update_lead(visitor_id):
 @app.route('/api/admin/leads/<visitor_id>/conversations', methods=['GET'])
 @login_required
 def get_lead_conversations(visitor_id):
+    if not visitor_id or visitor_id in ['null', 'undefined']:
+        return jsonify({"error": "Invalid visitor_id"}), 400
     try:
         history_response = supabase_client.table("conversations").select("role, content, created_at").eq("visitor_id", visitor_id).order("created_at", desc=False).execute()
         return jsonify(history_response.data)

--- a/backend/static/admin/dashboard.js
+++ b/backend/static/admin/dashboard.js
@@ -63,16 +63,19 @@ document.addEventListener('DOMContentLoaded', () => {
         leads.forEach(lead => {
             const tr = document.createElement('tr');
             tr.className = 'border-b dark:border-gray-700';
+            const historyDisabled = !lead.visitor_id ? 'disabled opacity-50 cursor-not-allowed' : '';
+            const editDisabled = !lead.visitor_id ? 'disabled opacity-50 cursor-not-allowed' : '';
+
             tr.innerHTML = `
                 <td class="p-4">${lead.name || 'N/A'}</td>
                 <td class="p-4">${lead.email || 'N/A'}</td>
                 <td class="p-4">${lead.phone || 'N/A'}</td>
                 <td class="p-4">${new Date(lead.created_at).toLocaleString('fr-FR')}</td>
                 <td class="p-4 space-x-2">
-                    <button class="history-button text-blue-500 hover:underline" data-visitor-id="${lead.visitor_id}" data-lead-name="${lead.name || 'Inconnu'}">
+                    <button class="history-button text-blue-500 hover:underline ${historyDisabled}" data-visitor-id="${lead.visitor_id}" data-lead-name="${lead.name || 'Inconnu'}" ${historyDisabled}>
                         Historique
                     </button>
-                    <button class="edit-button text-green-500 hover:underline" data-visitor-id="${lead.visitor_id}">
+                    <button class="edit-button text-green-500 hover:underline ${editDisabled}" data-visitor-id="${lead.visitor_id}" ${editDisabled}>
                         Modifier
                     </button>
                 </td>


### PR DESCRIPTION
…for missing visitor_ids.

On the frontend (`dashboard.js`):
- The 'Historique' (History) and 'Modifier' (Edit) buttons in the leads table are now disabled with a visual indicator if the lead does not have a `visitor_id`. This prevents you from performing actions on leads that cannot have associated conversations or be edited.

On the backend (`app.py`):
- The `/api/admin/leads/<visitor_id>/conversations` endpoint now validates the `visitor_id` and returns a 400 Bad Request if it is missing or invalid (e.g., 'null'). This makes the API more robust.

These changes address the issue where the history feature would 'not work well' for certain leads, providing you with a clearer and more error-proof experience.